### PR TITLE
use as package to export to os via os package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 main
 /bin
 /vendor
+.idea/

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -162,9 +162,8 @@ func MustSetOS(paths, tags []string) {
 	}
 	nameValues := getParamNameValues(params)
 	for name, value := range nameValues {
-		if err := os.Setenv(name, value); err != nil{
+		if err := os.Setenv(name, value); err != nil {
 			panic(err)
 		}
 	}
 }
-

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -1,0 +1,174 @@
+package fetch
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+var (
+	client *ssm.SSM
+	paths  []string
+	tags   []string
+
+	trueBool = true
+)
+
+func init() {
+	// initialize AWS client
+	initClient()
+}
+
+func initClient() {
+	session := session.Must(session.NewSession())
+	client = ssm.New(session)
+}
+
+func FetchParams(paths, tags []string) ([]*ssm.Parameter, error) {
+	// create tag filters
+	tagFilters := make([]*ssm.ParameterStringFilter, len(tags))
+	for i, tag := range tags {
+		tagFilter := fmt.Sprintf("tag:%s", tag)
+		tagFilters[i] = &ssm.ParameterStringFilter{
+			Key: &tagFilter,
+		}
+	}
+
+	// TEMP: until parameter-filters work for get-parameters-by-path (https://github.com/aws/aws-cli/issues/2850),
+	// 1) retrieve parameters by tags via describe-parameters
+	// 2) retrieve parameters by path via get-parameters-by-path
+	// 3) calculate union of two sets
+
+	// retrieve all parameters with given tags
+	paramNames, err := describeParams(tagFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	// retrieve params for given paths
+	params, err := getParamsByPath(paths)
+	if err != nil {
+		return params, err
+	}
+
+	// calculate union of two sets
+	union := calcUnion(paramNames, params)
+
+	return union, nil
+}
+
+func describeParams(filters []*ssm.ParameterStringFilter) ([]string, error) {
+	paramNames := make([]string, 0)
+
+	done := false
+	var nextToken string
+	for !done {
+		input := &ssm.DescribeParametersInput{
+			ParameterFilters: filters,
+		}
+
+		if nextToken != "" {
+			input.SetNextToken(nextToken)
+		}
+
+		output, err := client.DescribeParameters(input)
+		if err != nil {
+			return paramNames, err
+		}
+
+		for _, param := range output.Parameters {
+			paramNames = append(paramNames, *param.Name)
+		}
+
+		// there are more parameters if nextToken is given in response
+		if output.NextToken != nil {
+			nextToken = *output.NextToken
+		} else {
+			done = true
+		}
+	}
+
+	return paramNames, nil
+}
+
+func getParamsByPath(paths []string) ([]*ssm.Parameter, error) {
+	params := make([]*ssm.Parameter, 0)
+
+	// retrieve params for all paths
+	for _, path := range paths {
+
+		done := false
+		var nextToken string
+		for !done {
+			input := &ssm.GetParametersByPathInput{
+				Path:           &path,
+				Recursive:      &trueBool,
+				WithDecryption: &trueBool,
+			}
+
+			if nextToken != "" {
+				input.SetNextToken(nextToken)
+			}
+
+			output, err := client.GetParametersByPath(input)
+			if err != nil {
+				return params, err
+			}
+
+			params = append(params, output.Parameters...)
+
+			// there are more parameters for this path if nextToken is given in response
+			if output.NextToken != nil {
+				nextToken = *output.NextToken
+			} else {
+				done = true
+			}
+		}
+	}
+
+	return params, nil
+}
+
+func calcUnion(paramNames []string, params []*ssm.Parameter) []*ssm.Parameter {
+	// build map lookup
+	lookup := make(map[string]bool)
+	for _, paramName := range paramNames {
+		lookup[paramName] = true
+	}
+
+	// calculate union
+	union := make([]*ssm.Parameter, 0)
+	for _, param := range params {
+		if lookup[*param.Name] {
+			union = append(union, param)
+		}
+	}
+
+	return union
+}
+
+func getParamNameValues(params []*ssm.Parameter) map[string]string {
+	paramVals := make(map[string]string, len(params))
+	for _, param := range params {
+		split := strings.Split(*param.Name, "/")
+		name := split[len(split)-1]
+		paramVals[strings.ToUpper(name)] = *param.Value
+	}
+	return paramVals
+}
+
+func MustSetOS(paths, tags []string) {
+	params, err := FetchParams(paths, tags)
+	if err != nil {
+		panic(err)
+	}
+	nameValues := getParamNameValues(params)
+	for name, value := range nameValues {
+		if err := os.Setenv(name, value); err != nil{
+			panic(err)
+		}
+	}
+}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -172,3 +172,4 @@ func MustSetOS(paths, tags []string) {
 		}
 	}
 }
+

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -18,11 +18,6 @@ var (
 )
 
 func init() {
-	// initialize AWS client
-	initClient()
-}
-
-func initClient() {
 	session := session.Must(session.NewSession())
 	client = ssm.New(session)
 }

--- a/main.go
+++ b/main.go
@@ -88,3 +88,4 @@ func getParamNameValues(params []*ssm.Parameter) map[string]string {
 	}
 	return paramVals
 }
+

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/gametimesf/aws-ssm-env/fetch"
 )
 
 var (
@@ -26,7 +27,7 @@ func main() {
 	initFlags()
 
 	// fetch parameters
-	params, err := fetchParams(paths, tags)
+	params, err := fetch.FetchParams(paths, tags)
 	if err != nil {
 		panic(err)
 	}
@@ -69,129 +70,6 @@ func initTags(tagsFlag *string) {
 	}
 }
 
-func fetchParams(paths, tags []string) ([]*ssm.Parameter, error) {
-	// create tag filters
-	tagFilters := make([]*ssm.ParameterStringFilter, len(tags))
-	for i, tag := range tags {
-		tagFilter := fmt.Sprintf("tag:%s", tag)
-		tagFilters[i] = &ssm.ParameterStringFilter{
-			Key: &tagFilter,
-		}
-	}
-
-	// TEMP: until parameter-filters work for get-parameters-by-path (https://github.com/aws/aws-cli/issues/2850),
-	// 1) retrieve parameters by tags via describe-parameters
-	// 2) retrieve parameters by path via get-parameters-by-path
-	// 3) calculate union of two sets
-
-	// retrieve all parameters with given tags
-	paramNames, err := describeParams(tagFilters)
-	if err != nil {
-		return nil, err
-	}
-
-	// retrieve params for given paths
-	params, err := getParamsByPath(paths)
-	if err != nil {
-		return params, err
-	}
-
-	// calculate union of two sets
-	union := calcUnion(paramNames, params)
-
-	return union, nil
-}
-
-func describeParams(filters []*ssm.ParameterStringFilter) ([]string, error) {
-	paramNames := make([]string, 0)
-
-	done := false
-	var nextToken string
-	for !done {
-		input := &ssm.DescribeParametersInput{
-			ParameterFilters: filters,
-		}
-
-		if nextToken != "" {
-			input.SetNextToken(nextToken)
-		}
-
-		output, err := client.DescribeParameters(input)
-		if err != nil {
-			return paramNames, err
-		}
-
-		for _, param := range output.Parameters {
-			paramNames = append(paramNames, *param.Name)
-		}
-
-		// there are more parameters if nextToken is given in response
-		if output.NextToken != nil {
-			nextToken = *output.NextToken
-		} else {
-			done = true
-		}
-	}
-
-	return paramNames, nil
-}
-
-func getParamsByPath(paths []string) ([]*ssm.Parameter, error) {
-	params := make([]*ssm.Parameter, 0)
-
-	// retrieve params for all paths
-	for _, path := range paths {
-
-		done := false
-		var nextToken string
-		for !done {
-			input := &ssm.GetParametersByPathInput{
-				Path:           &path,
-				Recursive:      &trueBool,
-				WithDecryption: &trueBool,
-			}
-
-			if nextToken != "" {
-				input.SetNextToken(nextToken)
-			}
-
-			output, err := client.GetParametersByPath(input)
-			if err != nil {
-				return params, err
-			}
-
-			params = append(params, output.Parameters...)
-
-			// there are more parameters for this path if nextToken is given in response
-			if output.NextToken != nil {
-				nextToken = *output.NextToken
-			} else {
-				done = true
-			}
-		}
-	}
-
-	return params, nil
-}
-
-func calcUnion(paramNames []string, params []*ssm.Parameter) []*ssm.Parameter {
-	// build map lookup
-	lookup := make(map[string]bool)
-	for _, paramName := range paramNames {
-		lookup[paramName] = true
-	}
-
-	// calculate union
-	union := make([]*ssm.Parameter, 0)
-	for _, param := range params {
-		if lookup[*param.Name] {
-			union = append(union, param)
-		}
-	}
-
-	return union
-}
-
 func printParams(params []*ssm.Parameter) {
 	for _, param := range params {
 		split := strings.Split(*param.Name, "/")
@@ -209,17 +87,4 @@ func getParamNameValues(params []*ssm.Parameter) map[string]string {
 		paramVals[strings.ToUpper(name)] = *param.Value
 	}
 	return paramVals
-}
-
-func MustSetOS(paths, tags []string) {
-	params, err := fetchParams(paths, tags)
-	if err != nil {
-		panic(err)
-	}
-	nameValues := getParamNameValues(params)
-	for name, value := range nameValues {
-		if err := os.Setenv(name, value); err != nil{
-			panic(err)
-		}
-	}
 }


### PR DESCRIPTION
this project supports a CLI entry point to support exporting SSM params to environment variables via shell `export` commands.

this change is to include an entry point for applications to use directly, and export the same SSM params to environment variables using `os.Setenv`.