### PR TITLE
configure ssm client with optional region

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
@@ -18,8 +19,13 @@ var (
 )
 
 func init() {
+	awsConfig := aws.NewConfig()
+	ssmRegion := os.Getenv("SSM_REGION")
+	if ssmRegion != "" {
+		awsConfig = awsConfig.WithRegion(ssmRegion)
+	}
 	session := session.Must(session.NewSession())
-	client = ssm.New(session)
+	client = ssm.New(session, awsConfig)
 }
 
 func FetchParams(paths, tags []string) ([]*ssm.Parameter, error) {

--- a/main.go
+++ b/main.go
@@ -78,7 +78,6 @@ func printParams(params []*ssm.Parameter) {
 	}
 }
 
-
 func getParamNameValues(params []*ssm.Parameter) map[string]string {
 	paramVals := make(map[string]string, len(params))
 	for _, param := range params {
@@ -88,4 +87,3 @@ func getParamNameValues(params []*ssm.Parameter) map[string]string {
 	}
 	return paramVals
 }
-


### PR DESCRIPTION
sometimes services run in regions different from their SSM params region.

added optional `SSM_REGION` environment var to configure the SSM client, if appropriate.