### PR TITLE
Upgrade Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # credit: https://vic.demuzere.be/articles/golang-makefile-crosscompile/
-PLATFORMS := darwin/386 darwin/amd64 linux/386 linux/amd64 windows/386 windows/amd64
+PLATFORMS := darwin/arm64 darwin/amd64 linux/386 linux/amd64 linux/arm64 windows/386 windows/amd64
 
 checkenv:
 ifndef TAG

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Or download [binary](https://github.com/gametimesf/aws-ssm-env/releases/latest):
 > chmod 755 aws-ssm-env
 ```
 
+### Release File Generation
+Follow the steps below to create the zip files needed for the release. The value for tag should match your release tag version.
+```
+export TAG=v2.0.2
+make release
+```
+
+**Note**: If you receive the following error: `unknown directive: toolchain`, you must first upgrade to Go 1.21 or higher.
+
 ### Author
 Jamie Tsao
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gametimesf/aws-ssm-env/v2
 
-go 1.18
+go 1.21.5
 
 require github.com/aws/aws-sdk-go v1.44.151
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gametimesf/aws-ssm-env/v2
 
-go 1.21.5
+go 1.18
 
 require github.com/aws/aws-sdk-go v1.44.151
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gametimesf/aws-ssm-env/v2
 
 go 1.18
 
+toolchain go1.21.5
+
 require github.com/aws/aws-sdk-go v1.44.151
 
 require github.com/jmespath/go-jmespath v0.4.0 // indirect


### PR DESCRIPTION
## To be released as v2.0.2
The update to the go.mod will ensure that compilation will occur with Go >= v2.21.5. After merge, I'll release a new version with the new binaries compiled with the toolchain version.

## PR does the following
1. Go toolchain version upgrade for security patches
2. Updates the Makefile to support arm64 compilation and removal of Darwin/386 as it's [no longer supported by Go](https://go.dev/doc/go1.15)

## How has this been tested
This has been tested locally with the darwin/arm64 binary. After the release this will be tested in our testing env for a few services and if successful rolled out to higher envs.