### PR TITLE
fix: do not reference a feature introduced later than the declared go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gametimesf/aws-ssm-env/v2
 
-go 1.18
+go 1.21
 
 toolchain go1.21.5
 


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description
[dependabot cannot parse this repo's go.mod](https://github.com/gametimesf/aws-ssm-env/pull/150#issuecomment-1998499928)

## This is how I decided to implement/fix it
bump go version to match when `toolchain` was introduced

## JIRA link
n/a

## What does this change affect? (What can this break?)
nothing

## How has this been tested
n/a

## Observability
n/a

### How will this change be monitored
n/a