### PR TITLE
build: add goreleaser action for streamlined releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.22
+
+      - name: Create GitHub release
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          # doesn't matter because we're only triggering on tags
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ main
 /bin
 /vendor
 .idea/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description

Add goreleaser for creating GitHub releases with cross-platform binaries upon tagging the repo.

## This is how I decided to implement/fix it

I added [Goreleaser](https://goreleaser.com/) to the project. It is a tool that automates the process of releasing Go binaries. It creates GitHub releases with cross-platform binaries upon tagging the repo.

I chose this over Google's slightly more automated [release-please-action](https://github.com/google-github-actions/release-please-action) because this repo doesn't strictly conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so I'm not sure what would happen exactly with semantic version bumps and changelogs.

This supports the following OSes:
  - Linux
  - MacOS
  - Windows

... and will build binaries for various architectures.

## What does this change affect? (What can this break?)

It affects strictly the build process, so nothing in particular should break (current build artifacts are opinionated).

## How has this been tested

It hasn't.

## Observability

Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?

- [ ] Do your metrics follow the naming conventions?

### How will this change be monitored
