### PR TITLE
build: fix the accidental separation of actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-      - uses: actions/setup-go@v4
+        uses: actions/setup-go@v4
         with:
           go-version: 1.22
 


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description

The bug is that there was an extra `-` that made it seem like the title of an action belonged to a separate action, and thus there was no required `uses` or `run` attribute.

## This is how I decided to implement/fix it

Remove the `-`.

## What does this change affect? (What can this break?)

Just the one action step.

## How has this been tested

## Observability

Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?

- [ ] Do your metrics follow the naming conventions?

### How will this change be monitored
