### PR TITLE
build: adjust name template for releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,19 +20,15 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of `uname`.
+  - format: zip
     name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
+      {{ .ProjectName }}-
+      {{ .Tag }}-
+      {{- tolower .Os }}-
+      {{- if eq .Arch "x86_64" }}amd64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
 
 changelog:
   sort: asc


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description

I adjusted the name template variables according to [goreleaser docs](https://goreleaser.com/customization/templates/).

## This is how I decided to implement/fix it

This should result in the following:

`{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}.zip`
(aws-ssm-env-v1.1.1-linux-amd64.zip)

## What does this change affect? (What can this break?)
Describe the critical path(s) affected as well as the related component and system functions.

## How has this been tested

## Observability

Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?

- [ ] Do your metrics follow the naming conventions?

### How will this change be monitored
