### PR TITLE
build: remove random period in build name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ archives:
   - format: zip
     name_template: >-
       {{ .ProjectName }}-
-      {{ .Tag }}-
+      v{{ .Version }}-
       {{- tolower .Os }}-
       {{- if eq .Arch "x86_64" }}amd64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description

There's a weird period in the build artifact name.

## This is how I decided to implement/fix it

Instead of `{{ .Tag }}`, I'm using `v{{ .Version }}` (the "v" is stripped otherwise).

## What does this change affect? (What can this break?)
Describe the critical path(s) affected as well as the related component and system functions.

## How has this been tested

## Observability

Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?

- [ ] Do your metrics follow the naming conventions?

### How will this change be monitored
