### PR TITLE
BE-11621 - added a setter pkg. it can be used to update paramstore values

### DIFF
--- a/setter/setter.go
+++ b/setter/setter.go
@@ -11,7 +11,7 @@ import (
 
 type (
 	Setter interface {
-		Set(key string, value interface{})
+		PutParameter(ctx context.Context, key string, value string, valueType string, allowOverwrite bool) error
 	}
 
 	service struct {

--- a/setter/setter.go
+++ b/setter/setter.go
@@ -19,10 +19,9 @@ type (
 	}
 )
 
-// New creates a new service that can store key value pairs in the parameter store
+// NewSetter creates a new service that can store key value pairs in the parameter store
 // ssmRegion: the region where the parameter store is located
-// debug: if true, debug logs will be printed
-func New(ssmRegion string, debug bool) *service {
+func NewSetter(ssmRegion string, debug bool) *service {
 	awsConfig := aws.NewConfig()
 	if ssmRegion != "" {
 		awsConfig = awsConfig.WithRegion(ssmRegion)

--- a/setter/setter.go
+++ b/setter/setter.go
@@ -1,0 +1,62 @@
+package setter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+type (
+	Setter interface {
+		Set(key string, value interface{})
+	}
+
+	service struct {
+		client *ssm.SSM
+	}
+)
+
+// New creates a new service that can store key value pairs in the parameter store
+// ssmRegion: the region where the parameter store is located
+// debug: if true, debug logs will be printed
+func New(ssmRegion string, debug bool) *service {
+	awsConfig := aws.NewConfig()
+	if ssmRegion != "" {
+		awsConfig = awsConfig.WithRegion(ssmRegion)
+	}
+
+	session := session.Must(session.NewSession())
+	client := ssm.New(session, awsConfig)
+
+	return &service{
+		client: client,
+	}
+}
+
+// PutParameter stores/update the key value pair in the parameter store
+// key: the name of the parameter
+// value: the value of the parameter
+// valueType: the type of the parameter. accepted types (String, StringList, SecureString)
+// allowOverwrite: if true, the parameter will be overwritten if it already exists
+func (s *service) PutParameter(ctx context.Context, key string, value string, valueType string, allowOverwrite bool) error {
+	if valueType == "" || (valueType != "String" && valueType != "StringList" && valueType != "SecureString") {
+		return fmt.Errorf("invalid value_type, use one of the expected values")
+	}
+
+	// Create/Update the parameter
+	input := &ssm.PutParameterInput{
+		Name:      aws.String(key),
+		Value:     aws.String(value),
+		Type:      aws.String(valueType),
+		Overwrite: aws.Bool(allowOverwrite),
+	}
+
+	if _, err := s.client.PutParameterWithContext(ctx, input); err != nil {
+		return fmt.Errorf("failed to put parameter %s: %v", key, err)
+	}
+
+	return nil
+}

--- a/setter/setter.go
+++ b/setter/setter.go
@@ -21,7 +21,7 @@ type (
 
 // NewSetter creates a new service that can store key value pairs in the parameter store
 // ssmRegion: the region where the parameter store is located
-func NewSetter(ssmRegion string, debug bool) *service {
+func NewSetter(ssmRegion string) *service {
 	awsConfig := aws.NewConfig()
 	if ssmRegion != "" {
 		awsConfig = awsConfig.WithRegion(ssmRegion)


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description
allow service to write/update values in paramstore. this should be used for refreshable shortlived keys

## This is how I decided to implement/fix it

1. added a setter pkg with the functionality necessary for upsert values

## JIRA link
https://gametime.atlassian.net/browse/BE-11621

## What does this change affect? (What can this break?)
Describe the critical path(s) affected as well as the related component and system functions.

## How has this been tested
pending
